### PR TITLE
ENH: show diff of pre-commit config in action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,11 +19,13 @@ runs:
         curl -LsSf https://astral.sh/uv/install.sh | sh
         source $HOME/.cargo/env
       shell: bash
-    - run: uv pip install --color=always --system pre-commit
+    - name: Install pre-commit
+      run: uv pip install --color=always --system pre-commit
       shell: bash
     - run: pre-commit autoupdate --color=always
       shell: bash
-    - run: git diff --color --unified=0
+    - name: Show changes
+      run: git diff --color --unified=0
       shell: bash
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Improves the [ComPWA/update-pre-commit@v1](https://github.com/ComPWA/update-pre-commit/blob/175edd06b376d35750155103c186e808a0f08db7/action.yml) action
- Show changes to the `.pre-commit-config.yaml` with colorized `git diff`
- Switch to `uv pip install` (not that much speed improvement)
- Colorize output of `pre-commit autoupdate` (not any effect)