### PR TITLE
ENH: run `autoupdate` with `pre-commit-uv`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,6 @@ runs:
       shell: bash
     - uses: actions/upload-artifact@v4
       with:
+        if-no-files-found: error
         name: pre-commit
         path: .pre-commit-config.yaml

--- a/action.yml
+++ b/action.yml
@@ -25,5 +25,6 @@ runs:
     - uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
+        include-hidden-files: true
         name: pre-commit
         path: .pre-commit-config.yaml

--- a/action.yml
+++ b/action.yml
@@ -10,19 +10,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
-    - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        source $HOME/.cargo/env
-      shell: bash
-    - name: Install pre-commit
-      run: uv pip install --color=always --system pre-commit
-      shell: bash
-    - run: pre-commit autoupdate --color=always
+    - uses: astral-sh/setup-uv@v3
+    - env:
+        FORCE_COLOR: True
+        UV_SYSTEM_PYTHON: True
+      run: uvx --with pre-commit-uv pre-commit autoupdate
       shell: bash
     - name: Show changes
       run: git diff --color --unified=0

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ description: Run pre-commit autoupdate and upload config file as artifact
 inputs:
   python-version:
     description: Python version to run pre-commit with
-    default: "3.9"
+    default: "3.12"
     required: true
 
 runs:


### PR DESCRIPTION
- Speed up `autoupdate` with [`pre-commit-uv`](https://pypi.org/project/pre-commit-uv)
- Run workflow on Python 3.12 by default
- Upload hidden files, that is, including `.` files and therefore `.pre-commit-config.yaml`
- Fail workflow if no `.pre-commit-config.yaml` is present